### PR TITLE
David/DLS-358/Remove-Compiler-Warnings

### DIFF
--- a/app/uk/gov/hmrc/cbcr/auth/CBCRAuth.scala
+++ b/app/uk/gov/hmrc/cbcr/auth/CBCRAuth.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.AuthProvider.GovernmentGateway
 import uk.gov.hmrc.auth.core.retrieve.{AuthProviders, Retrieval}
-import uk.gov.hmrc.auth.core.retrieve.Retrievals.affinityGroup
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.affinityGroup
 import uk.gov.hmrc.cbcr.config.GenericAppConfig
 import uk.gov.hmrc.http.{HeaderCarrier, HttpPost}
 import uk.gov.hmrc.play.config.ServicesConfig

--- a/app/uk/gov/hmrc/cbcr/repositories/FileUploadRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/FileUploadRepository.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoApi
 import reactivemongo.api.commands.WriteResult
 import reactivemongo.play.json.collection.JSONCollection
-import reactivemongo.play.json._
+import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
 import uk.gov.hmrc.cbcr.models.UploadFileResponse
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -40,7 +40,7 @@ class FileUploadRepository @Inject() (val mongo: ReactiveMongoApi)(implicit ec:E
 
   def get(envelopeId:String): Future[Option[UploadFileResponse]] = {
     val criteria = Json.obj("envelopeId" -> envelopeId)
-    repository.flatMap(_.find(criteria).one[UploadFileResponse])
+    repository.flatMap(_.find(criteria, None).one[UploadFileResponse])
   }
 
 }

--- a/app/uk/gov/hmrc/cbcr/repositories/MessageRefIdRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/MessageRefIdRepository.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoApi
 import reactivemongo.api.commands.WriteResult
 import reactivemongo.play.json.collection.JSONCollection
-import reactivemongo.play.json._
+import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
 import uk.gov.hmrc.cbcr.models.MessageRefId
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,14 +39,14 @@ class MessageRefIdRepository@Inject() (val mongo: ReactiveMongoApi)(implicit ec:
 
   def exists(messageRefId: String): Future[Boolean] = {
     val criteria = Json.obj("messageRefId" -> messageRefId)
-    repository.flatMap(_.find(criteria).one[MessageRefId].map(_.isDefined))
+    repository.flatMap(_.find(criteria, None).one[MessageRefId].map(_.isDefined))
   }
 
   def delete(m:MessageRefId): Future[WriteResult] = {
     val criteria = Json.obj("messageRefId" -> m.id)
     for {
       repo <- repository
-      x    <- repo.remove(criteria)
+      x    <- repo.delete().one(criteria)
     } yield  x
   }
 }

--- a/test/uk/gov/hmrc/cbcr/auth/CBCRAuthSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/auth/CBCRAuthSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cbcr.auth
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.mvc.Results.{Ok, Unauthorized}
 import play.api.mvc.{AnyContent, Request, Result}

--- a/test/uk/gov/hmrc/cbcr/controllers/CBCIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/CBCIdControllerSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.ActorMaterializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, Matchers}
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Configuration

--- a/test/uk/gov/hmrc/cbcr/controllers/CBCREmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/CBCREmailControllerSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cbcr.controllers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import uk.gov.hmrc.cbcr.models._

--- a/test/uk/gov/hmrc/cbcr/controllers/DocRefIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/DocRefIdControllerSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.ActorMaterializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Configuration
 import play.api.http.Status

--- a/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.ActorMaterializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.json.Json._

--- a/test/uk/gov/hmrc/cbcr/controllers/MessageRefIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/MessageRefIdControllerSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.ActorMaterializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.test.{FakeRequest, Helpers}
 import reactivemongo.api.commands.{DefaultWriteResult, WriteError}

--- a/test/uk/gov/hmrc/cbcr/controllers/MockAuth.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/MockAuth.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cbcr.controllers
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import uk.gov.hmrc.auth.core.AffinityGroup
 import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.cbcr.auth.{CBCRAuth, MicroServiceAuthConnector}

--- a/test/uk/gov/hmrc/cbcr/controllers/ReportingEntityDataControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/ReportingEntityDataControllerSpec.scala
@@ -24,7 +24,7 @@ import cats.data.NonEmptyList
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.{FakeRequest, Helpers}

--- a/test/uk/gov/hmrc/cbcr/controllers/SubscriptionDataControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/SubscriptionDataControllerSpec.scala
@@ -22,7 +22,7 @@ import cats.data.OptionT
 import cats.instances.future._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Configuration
 import play.api.http.Status

--- a/test/uk/gov/hmrc/cbcr/controllers/package.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/package.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cbcr
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import uk.gov.hmrc.auth.core.AffinityGroup
 import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.cbcr.auth.{CBCRAuth, MicroServiceAuthConnector}

--- a/test/uk/gov/hmrc/cbcr/services/AuditSubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/AuditSubscriptionServiceSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cbcr.services
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when, _}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Configuration
 import play.api.libs.json.JsString

--- a/test/uk/gov/hmrc/cbcr/services/DocRefIdClearServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/DocRefIdClearServiceSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cbcr.services
 
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Configuration
 import uk.gov.hmrc.cbcr.controllers.MockAuth

--- a/test/uk/gov/hmrc/cbcr/services/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/EmailServiceSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cbcr.services
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Configuration
 import play.api.mvc.Result

--- a/test/uk/gov/hmrc/cbcr/services/LocalSubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/LocalSubscriptionSpec.scala
@@ -27,7 +27,7 @@ import com.typesafe.config.ConfigFactory
 import org.mockito.Mockito._
 import org.scalatest.Matchers
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Configuration
 import play.api.http.Status

--- a/test/uk/gov/hmrc/cbcr/services/RemoteSubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/RemoteSubscriptionSpec.scala
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import uk.gov.hmrc.cbcr.connectors.DESConnector
 import uk.gov.hmrc.cbcr.models._
 import uk.gov.hmrc.emailaddress.EmailAddress

--- a/test/uk/gov/hmrc/cbcr/services/RunModeSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/RunModeSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.cbcr.services
 
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Configuration
 import uk.gov.hmrc.play.test.UnitSpec


### PR DESCRIPTION
David/DLS-358/Remove-Compiler-Warnings

Maintenance

Removed roughly around 70% of the warnings. The warnings I left were mostly deprecations for methods in reactivemongo.api.collections. The latest versions required a few more parameters adding, which I wasn't entirely comfortable doing.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date