### PR TITLE
DLS-6575: Copy right 2023 changes and Fixing unit tests for ReportingEntityDataRepoSpec.

### DIFF
--- a/app/uk/gov/hmrc/cbcr/Module.scala
+++ b/app/uk/gov/hmrc/cbcr/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/auth/CBCRAuth.scala
+++ b/app/uk/gov/hmrc/cbcr/auth/CBCRAuth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/connectors/DESConnector.scala
+++ b/app/uk/gov/hmrc/cbcr/connectors/DESConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/cbcr/connectors/EmailConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/connectors/RawResponseReads.scala
+++ b/app/uk/gov/hmrc/cbcr/connectors/RawResponseReads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/BusinessPartnerRecordController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/BusinessPartnerRecordController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/CBCIdController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/CBCIdController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/CBCREmailController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/CBCREmailController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/DocRefIdController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/DocRefIdController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/FileUploadResponseController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/FileUploadResponseController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/MessageRefIdController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/MessageRefIdController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/ReportingEntityDataController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/ReportingEntityDataController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/SubscriptionDataController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/SubscriptionDataController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/controllers/test/TestSubscriptionDataController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/test/TestSubscriptionDataController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/BusinessPartnerRecord.scala
+++ b/app/uk/gov/hmrc/cbcr/models/BusinessPartnerRecord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/CBCId.scala
+++ b/app/uk/gov/hmrc/cbcr/models/CBCId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/CountryCode.scala
+++ b/app/uk/gov/hmrc/cbcr/models/CountryCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/DatesOverlap.scala
+++ b/app/uk/gov/hmrc/cbcr/models/DatesOverlap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/DbOperationResult.scala
+++ b/app/uk/gov/hmrc/cbcr/models/DbOperationResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/DesErrorResults.scala
+++ b/app/uk/gov/hmrc/cbcr/models/DesErrorResults.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/DocRefID.scala
+++ b/app/uk/gov/hmrc/cbcr/models/DocRefID.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/Email.scala
+++ b/app/uk/gov/hmrc/cbcr/models/Email.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/InvalidState.scala
+++ b/app/uk/gov/hmrc/cbcr/models/InvalidState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/MessageRefId.scala
+++ b/app/uk/gov/hmrc/cbcr/models/MessageRefId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/Migration.scala
+++ b/app/uk/gov/hmrc/cbcr/models/Migration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/ReportingEntityData.scala
+++ b/app/uk/gov/hmrc/cbcr/models/ReportingEntityData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/ReportingRole.scala
+++ b/app/uk/gov/hmrc/cbcr/models/ReportingRole.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/SubscriptionData.scala
+++ b/app/uk/gov/hmrc/cbcr/models/SubscriptionData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/SubscriptionRequest.scala
+++ b/app/uk/gov/hmrc/cbcr/models/SubscriptionRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/TIN.scala
+++ b/app/uk/gov/hmrc/cbcr/models/TIN.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/UltimateParentEntity.scala
+++ b/app/uk/gov/hmrc/cbcr/models/UltimateParentEntity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/UploadFileResponse.scala
+++ b/app/uk/gov/hmrc/cbcr/models/UploadFileResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/models/Utr.scala
+++ b/app/uk/gov/hmrc/cbcr/models/Utr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/package.scala
+++ b/app/uk/gov/hmrc/cbcr/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/repositories/DocRefIdRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/DocRefIdRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/repositories/FileUploadRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/FileUploadRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/repositories/MessageRefIdRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/MessageRefIdRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/repositories/ReactiveDocRefIdRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/ReactiveDocRefIdRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/repositories/ReportingEntityDataRepo.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/ReportingEntityDataRepo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cbcr.repositories
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.Filters.{equal, regex}
 import org.mongodb.scala.model.Indexes.ascending
-import org.mongodb.scala.model.Updates.{set, unset}
+import org.mongodb.scala.model.Updates.{combine, set, unset}
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions}
 import org.mongodb.scala.result.{DeleteResult, InsertOneResult}
 import play.api.libs.json._
@@ -76,7 +76,7 @@ class ReportingEntityDataRepo @Inject()(val mongo: MongoComponent)(implicit ec: 
     collection
       .findOneAndUpdate(
         equal("reportingEntityDRI", docRefId.id),
-        Seq(
+        combine(
           set("cbcReportsDRI", Codecs.toBson(admin.cbcReportsDRI)),
           set("additionalInfoDRI", Codecs.toBson(admin.additionalInfoDRI)),
           set("reportingEntityDRI", Codecs.toBson(admin.reportingEntityDRI)),
@@ -109,7 +109,7 @@ class ReportingEntityDataRepo @Inject()(val mongo: MongoComponent)(implicit ec: 
                      throw new NoSuchElementException("Original report not found in Mongo, while trying to update.")
                  }
         modifier = buildModifier(p, record)
-        update <- collection.findOneAndUpdate(condition, modifier).toFutureOption()
+        update <- collection.findOneAndUpdate(condition, combine(modifier: _*)).toFutureOption()
       } yield update.isDefined
     }
 

--- a/app/uk/gov/hmrc/cbcr/repositories/SubscriptionDataRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/SubscriptionDataRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/AdminService.scala
+++ b/app/uk/gov/hmrc/cbcr/services/AdminService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/AuditSubscriptionService.scala
+++ b/app/uk/gov/hmrc/cbcr/services/AuditSubscriptionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/CBCIdGenerator.scala
+++ b/app/uk/gov/hmrc/cbcr/services/CBCIdGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/DocRefIdClearService.scala
+++ b/app/uk/gov/hmrc/cbcr/services/DocRefIdClearService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/EmailService.scala
+++ b/app/uk/gov/hmrc/cbcr/services/EmailService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/LocalSubscription.scala
+++ b/app/uk/gov/hmrc/cbcr/services/LocalSubscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/RemoteSubscription.scala
+++ b/app/uk/gov/hmrc/cbcr/services/RemoteSubscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/RetrieveReportingEntityService.scala
+++ b/app/uk/gov/hmrc/cbcr/services/RetrieveReportingEntityService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/RunMode.scala
+++ b/app/uk/gov/hmrc/cbcr/services/RunMode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/services/SubscriptionHandler.scala
+++ b/app/uk/gov/hmrc/cbcr/services/SubscriptionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcr/typeclasses/AsResult.scala
+++ b/app/uk/gov/hmrc/cbcr/typeclasses/AsResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.7.2

--- a/test/resources/test.application.conf
+++ b/test/resources/test.application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/actors/CBCIdGeneratorSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/actors/CBCIdGeneratorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/auth/CBCRAuthSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/auth/CBCRAuthSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/connectors/DESConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/connectors/DESConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/connectors/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/connectors/EmailConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/BusinessPartnerRecordControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/BusinessPartnerRecordControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/CBCIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/CBCIdControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/CBCREmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/CBCREmailControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/CSRFTest.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/CSRFTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/DocRefIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/DocRefIdControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/MessageRefIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/MessageRefIdControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/MockAuth.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/MockAuth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/ReportingEntityDataControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/ReportingEntityDataControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/SubscriptionDataControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/SubscriptionDataControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/controllers/package.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/models/CBCIdSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/models/CBCIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/models/DocRefIdSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/models/DocRefIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/models/ReportingEntityDataSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/models/ReportingEntityDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/repositories/DocRefIdRepositorySpec.scala
+++ b/test/uk/gov/hmrc/cbcr/repositories/DocRefIdRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/repositories/FileUploadRepositorySpec.scala
+++ b/test/uk/gov/hmrc/cbcr/repositories/FileUploadRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/repositories/MessageRefIdRepositorySpec.scala
+++ b/test/uk/gov/hmrc/cbcr/repositories/MessageRefIdRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/repositories/ReportingEntityDataRepoSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/repositories/ReportingEntityDataRepoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/repositories/SubscriptionDataRepositorySpec.scala
+++ b/test/uk/gov/hmrc/cbcr/repositories/SubscriptionDataRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/services/AdminServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/AdminServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/services/AuditSubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/AuditSubscriptionServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/services/DocRefIdClearServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/DocRefIdClearServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/services/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/EmailServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/services/LocalSubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/LocalSubscriptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/services/RemoteSubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/RemoteSubscriptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/services/RetrieveReportingEntityServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/RetrieveReportingEntityServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/services/RunModeSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/services/RunModeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/util/LogCapturing.scala
+++ b/test/uk/gov/hmrc/cbcr/util/LogCapturing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcr/util/UnitSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/util/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# DLS-6575: Revert the CBC Service Upscan changes and Re-Release the HMRC-Mongo Upgrade

**Bug fix 

Copy right 2023 changes and Fixing mongo related unit tests for ReportingEntityDataRepoSpec.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date