### PR TITLE
DLS-7280 Mongo Upsert and out of order updates fix

### DIFF
--- a/app/uk/gov/hmrc/cbcr/controllers/FileUploadResponseController.scala
+++ b/app/uk/gov/hmrc/cbcr/controllers/FileUploadResponseController.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.libs.json._
 import play.api.mvc.ControllerComponents
 import uk.gov.hmrc.cbcr.auth.CBCRAuth
-import uk.gov.hmrc.cbcr.models.UploadFileResponse
+import uk.gov.hmrc.cbcr.models.FileUploadResponse
 import uk.gov.hmrc.cbcr.repositories.FileUploadRepository
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
@@ -33,7 +33,7 @@ class FileUploadResponseController @Inject()(repo: FileUploadRepository, auth: C
 
   def saveFileUploadResponse = Action.async(parse.json) { implicit request =>
     request.body
-      .validate[UploadFileResponse]
+      .validate[FileUploadResponse]
       .fold(
         error => Future.successful(BadRequest(JsError.toJson(error))),
         response => repo.save2(response).map(_ => Ok)

--- a/app/uk/gov/hmrc/cbcr/models/FileUploadResponse.scala
+++ b/app/uk/gov/hmrc/cbcr/models/FileUploadResponse.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.cbcr.models
 
 import play.api.libs.json.Json
 
-case class UploadFileResponse(envelopeId: String, fileId: String, status: String, reason: Option[String])
+case class FileUploadResponse(envelopeId: String, fileId: String, status: String, reason: Option[String])
 
-object UploadFileResponse {
-  implicit val ufrFormat = Json.format[UploadFileResponse]
+object FileUploadResponse {
+  implicit val ufrFormat = Json.format[FileUploadResponse]
 }

--- a/app/uk/gov/hmrc/cbcr/repositories/FileUploadRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/FileUploadRepository.scala
@@ -20,7 +20,7 @@ import org.mongodb.scala.model.Filters.equal
 import org.mongodb.scala.result.InsertOneResult
 
 import javax.inject.{Inject, Singleton}
-import uk.gov.hmrc.cbcr.models.UploadFileResponse
+import uk.gov.hmrc.cbcr.models.FileUploadResponse
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 
@@ -28,15 +28,15 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class FileUploadRepository @Inject()(val mongo: MongoComponent)(implicit ec: ExecutionContext)
-    extends PlayMongoRepository[UploadFileResponse](
+    extends PlayMongoRepository[FileUploadResponse](
       mongoComponent = mongo,
       collectionName = "FileUpload",
-      domainFormat = UploadFileResponse.ufrFormat,
+      domainFormat = FileUploadResponse.ufrFormat,
       indexes = Seq()) {
 
-  def save2(f: UploadFileResponse): Future[InsertOneResult] = collection.insertOne(f).toFuture()
+  def save2(f: FileUploadResponse): Future[InsertOneResult] = collection.insertOne(f).toFuture()
 
-  def get(envelopeId: String): Future[Option[UploadFileResponse]] =
+  def get(envelopeId: String): Future[Option[FileUploadResponse]] =
     collection.find(equal("envelopeId", envelopeId)).headOption()
 
 }

--- a/app/uk/gov/hmrc/cbcr/repositories/ReportingEntityDataRepo.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/ReportingEntityDataRepo.scala
@@ -22,7 +22,6 @@ import org.mongodb.scala.model.Indexes.ascending
 import org.mongodb.scala.model.Updates.{combine, set, unset}
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions}
 import org.mongodb.scala.result.{DeleteResult, InsertOneResult}
-import play.api.libs.json._
 import uk.gov.hmrc.cbcr.models._
 import uk.gov.hmrc.cbcr.services.AdminReportingEntityData
 import uk.gov.hmrc.mongo.MongoComponent

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
     "org.typelevel"     %% "cats"                       % "0.9.0" exclude("org.scalacheck","scalacheck_2.12"),
     "com.github.kxbmap" %% "configs"                    % "0.6.0",
     "uk.gov.hmrc"       %% "emailaddress"               % "3.5.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % "0.73.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % "0.74.0",
     compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.5" cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib" % "1.7.5" % Provided cross CrossVersion.full,
     "org.codehaus.woodstox"    % "woodstox-core-asl"    % "4.4.1",
@@ -28,7 +28,7 @@ object AppDependencies {
     "org.mockito"             %  "mockito-core"            % "3.11.2"    % scope,
     "org.scalacheck"          %% "scalacheck"              % "1.15.0"    % scope,
     "com.github.tomakehurst"  %  "wiremock-standalone"     % "2.25.0"    % scope,
-    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28" % "0.73.0",
+    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28" % "0.74.0",
     "org.scalatestplus"       %% "scalatestplus-mockito"   % "1.0.0-M2"  % Test,
   )
 

--- a/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
@@ -40,11 +40,11 @@ import scala.concurrent.Future
   */
 class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with MockAuth {
 
-  val fir = FileUploadResponse("id1", "fid1", "status", None)
+  val fur = FileUploadResponse("id1", "fid1", "status", None)
 
   val okResult = InsertOneResult.acknowledged(BsonNull.VALUE)
 
-  val fakePostRequest: FakeRequest[JsValue] = FakeRequest(Helpers.POST, "/saveFileUploadResponse").withBody(toJson(fir))
+  val fakePostRequest: FakeRequest[JsValue] = FakeRequest(Helpers.POST, "/saveFileUploadResponse").withBody(toJson(fur))
 
   val badFakePostRequest: FakeRequest[JsValue] =
     FakeRequest(Helpers.POST, "/saveFileUploadResponse").withBody(Json.obj("bad" -> "request"))
@@ -65,8 +65,8 @@ class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with M
     }
 
     "protect the AVAILABLE status from being overridden" in {
-      val availableFur = fir.copy(status = "AVAILABLE")
-      val quarantinedFur = fir.copy(status = "QUARANTINED")
+      val availableFur = fur.copy(status = "AVAILABLE")
+      val quarantinedFur = fur.copy(status = "QUARANTINED")
       val argument: ArgumentCaptor[FileUploadResponse] = ArgumentCaptor.forClass(classOf[FileUploadResponse])
       when(repo.save2(argument.capture())).thenReturn(Future.successful(Some(availableFur)))
       val result = controller.saveFileUploadResponse(fakePostRequest.withBody(toJson(quarantinedFur)))
@@ -76,8 +76,8 @@ class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with M
     }
 
     "don't protect the AVAILABLE status from being overridden by DELETED" in {
-      val availableFur = fir.copy(status = "AVAILABLE")
-      val deletedFur = fir.copy(status = "DELETED")
+      val availableFur = fur.copy(status = "AVAILABLE")
+      val deletedFur = fur.copy(status = "DELETED")
       val argument: ArgumentCaptor[FileUploadResponse] = ArgumentCaptor.forClass(classOf[FileUploadResponse])
       when(repo.save2(argument.capture())).thenReturn(Future.successful(Some(availableFur)))
       val result = controller.saveFileUploadResponse(fakePostRequest.withBody(toJson(deletedFur)))
@@ -94,7 +94,7 @@ class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with M
     }
 
     "respond with a 200 and a FileUploadResponse when asked to retrieve an existing envelopeId" in {
-      when(repo.get(any(classOf[String]))).thenReturn(Future.successful(Some(fir)))
+      when(repo.get(any(classOf[String]))).thenReturn(Future.successful(Some(fur)))
       val result = controller.retrieveFileUploadResponse("envelopeIdOk")(fakeGetRequest)
       status(result) shouldBe Status.OK
       jsonBodyOf(result).validate[FileUploadResponse].isSuccess shouldBe true

--- a/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
@@ -21,6 +21,7 @@ import com.mongodb.client.result.InsertOneResult
 import org.bson.BsonNull
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
@@ -57,15 +58,15 @@ class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with M
   val controller = new FileUploadResponseController(repo, cBCRAuth, cc)
 
   "The FileUploadResponseController" should {
-    "respond with a 200 when asked to store an UploadFileResponse" in {
-      when(repo.save2(any(classOf[FileUploadResponse]))).thenReturn(Future.successful(okResult))
+    "respond with a 200 when asked to store an FileUploadResponse" in {
+      when(repo.save2(any(classOf[FileUploadResponse]))).thenReturn(Future.successful(Some(fir)))
       val result = controller.saveFileUploadResponse(fakePostRequest)
       status(result) shouldBe Status.OK
     }
 
-    "respond with a 400 if UploadFileResponse in request is invalid" in {
+    "respond with a 400 if FileUploadResponse in request is invalid" in {
       when(repo.save2(any(classOf[FileUploadResponse])))
-        .thenReturn(Future.failed[InsertOneResult](new RuntimeException()))
+        .thenReturn(Future.failed(new RuntimeException()))
       val result = controller.saveFileUploadResponse(badFakePostRequest)
       status(result) shouldBe Status.BAD_REQUEST
     }

--- a/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
@@ -39,7 +39,7 @@ import scala.concurrent.Future
   */
 class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with MockAuth {
 
-  val fir = UploadFileResponse("id1", "fid1", "status", None)
+  val fir = FileUploadResponse("id1", "fid1", "status", None)
 
   val okResult = InsertOneResult.acknowledged(BsonNull.VALUE)
 
@@ -58,13 +58,13 @@ class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with M
 
   "The FileUploadResponseController" should {
     "respond with a 200 when asked to store an UploadFileResponse" in {
-      when(repo.save2(any(classOf[UploadFileResponse]))).thenReturn(Future.successful(okResult))
+      when(repo.save2(any(classOf[FileUploadResponse]))).thenReturn(Future.successful(okResult))
       val result = controller.saveFileUploadResponse(fakePostRequest)
       status(result) shouldBe Status.OK
     }
 
     "respond with a 400 if UploadFileResponse in request is invalid" in {
-      when(repo.save2(any(classOf[UploadFileResponse])))
+      when(repo.save2(any(classOf[FileUploadResponse])))
         .thenReturn(Future.failed[InsertOneResult](new RuntimeException()))
       val result = controller.saveFileUploadResponse(badFakePostRequest)
       status(result) shouldBe Status.BAD_REQUEST
@@ -74,7 +74,7 @@ class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with M
       when(repo.get(any(classOf[String]))).thenReturn(Future.successful(Some(fir)))
       val result = controller.retrieveFileUploadResponse("envelopeIdOk")(fakeGetRequest)
       status(result) shouldBe Status.OK
-      jsonBodyOf(result).validate[UploadFileResponse].isSuccess shouldBe true
+      jsonBodyOf(result).validate[FileUploadResponse].isSuccess shouldBe true
     }
 
     "respond with a 204 when asked to retrieve a non-existent envelopeId" in {

--- a/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
@@ -17,8 +17,6 @@
 package uk.gov.hmrc.cbcr.controllers
 
 import akka.actor.ActorSystem
-import com.mongodb.client.result.InsertOneResult
-import org.bson.BsonNull
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
@@ -40,9 +38,7 @@ import scala.concurrent.Future
   */
 class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with MockAuth {
 
-  val fur = FileUploadResponse("id1", "fid1", "status", None)
-
-  val okResult = InsertOneResult.acknowledged(BsonNull.VALUE)
+  private val fur = FileUploadResponse("id1", "fid1", "status", None)
 
   val fakePostRequest: FakeRequest[JsValue] = FakeRequest(Helpers.POST, "/saveFileUploadResponse").withBody(toJson(fur))
 
@@ -51,9 +47,9 @@ class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with M
 
   val fakeGetRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(Helpers.GET, "/retrieveFileUploadResponse")
 
-  implicit val as = ActorSystem()
+  implicit val as: ActorSystem = ActorSystem()
 
-  val repo = mock[FileUploadRepository]
+  private val repo = mock[FileUploadRepository]
 
   val controller = new FileUploadResponseController(repo, cBCRAuth, cc)
 

--- a/test/uk/gov/hmrc/cbcr/repositories/FileUploadRepositorySpec.scala
+++ b/test/uk/gov/hmrc/cbcr/repositories/FileUploadRepositorySpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cbcr.repositories
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
 import uk.gov.hmrc.cbcr.controllers.MockAuth
-import uk.gov.hmrc.cbcr.models.UploadFileResponse
+import uk.gov.hmrc.cbcr.models.FileUploadResponse
 import uk.gov.hmrc.cbcr.util.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -31,7 +31,7 @@ class FileUploadRepositorySpec extends UnitSpec with MockAuth with GuiceOneAppPe
   implicit val ec = app.injector.instanceOf[ExecutionContext]
   implicit val hc = HeaderCarrier()
   val fileUploadRepository = app.injector.instanceOf[FileUploadRepository]
-  val fir = UploadFileResponse("id1", "fid1", "status", None)
+  val fir = FileUploadResponse("id1", "fid1", "status", None)
 
   "Calls to Save  UploadFileResponse" should {
     "should successfully save that UploadFileResponse" in {
@@ -45,7 +45,7 @@ class FileUploadRepositorySpec extends UnitSpec with MockAuth with GuiceOneAppPe
   "Calls to get a EnvelopId" should {
     "should successfully fetch that envelopId" in {
 
-      val result: Future[Option[UploadFileResponse]] = fileUploadRepository.get("id1")
+      val result: Future[Option[FileUploadResponse]] = fileUploadRepository.get("id1")
       await(result.map(r => r.get.envelopeId)) shouldBe "id1"
 
     }
@@ -54,7 +54,7 @@ class FileUploadRepositorySpec extends UnitSpec with MockAuth with GuiceOneAppPe
   "Calls to get a EnvelopId which does not exist" should {
     "should not fetch that envelopId" in {
 
-      val result: Future[Option[UploadFileResponse]] = fileUploadRepository.get("envelopeId")
+      val result: Future[Option[FileUploadResponse]] = fileUploadRepository.get("envelopeId")
       await(result.map(r => r)) shouldBe None
 
     }


### PR DESCRIPTION
# DLS-7280 Fix Mongo Upsert on FileUploadResponse

Bug fix

When porting our application across different Mongo libraries, we've introduced a bug - an upsert has been turned into an insert (resulting in duplicate entries). This fix aims to address that problem.

Additionally, it also fixes the following, related problem (which is already present in the live 1.154.0 version):

Approximately every 2 weeks we're seeing a spike of 204s on CBCR Frontend. I believe it's caused by FileUpload Responses coming out order - we first receive status "AVAILABLE" and then "QUARANTINED" - when asked about these files, FileUpload says they are indeed marked as "available". Normally the reverse is true. As a result, whenever CBCR-Frontend queries this service (which happens roughly every 2 weeks), we repeatedly reply with the last received status - QUARANTINED, which causes front-end and the browser to hang indefinitely.

In case this is not the case, nothing will change. In case it is happening, we shouldn't see another spike of 204s again.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date