### PR TITLE
DLS-9022 Race condition handling v2

### DIFF
--- a/app/uk/gov/hmrc/cbcr/repositories/FileUploadRepository.scala
+++ b/app/uk/gov/hmrc/cbcr/repositories/FileUploadRepository.scala
@@ -17,11 +17,9 @@
 package uk.gov.hmrc.cbcr.repositories
 
 import org.mongodb.scala.model.Filters.equal
-import org.mongodb.scala.model.Updates._
-import org.mongodb.scala.model.FindOneAndUpdateOptions
 import uk.gov.hmrc.cbcr.models.FileUploadResponse
 import uk.gov.hmrc.mongo.MongoComponent
-import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/controllers/FileUploadResponseControllerSpec.scala
@@ -60,28 +60,6 @@ class FileUploadResponseControllerSpec extends UnitSpec with ScalaFutures with M
       status(result) shouldBe Status.OK
     }
 
-    "protect the AVAILABLE status from being overridden" in {
-      val availableFur = fur.copy(status = "AVAILABLE")
-      val quarantinedFur = fur.copy(status = "QUARANTINED")
-      val argument: ArgumentCaptor[FileUploadResponse] = ArgumentCaptor.forClass(classOf[FileUploadResponse])
-      when(repo.save2(argument.capture())).thenReturn(Future.successful(Some(availableFur)))
-      val result = controller.saveFileUploadResponse(fakePostRequest.withBody(toJson(quarantinedFur)))
-
-      status(result) shouldBe Status.OK
-      argument.getAllValues should contain theSameElementsInOrderAs List(quarantinedFur, availableFur)
-    }
-
-    "don't protect the AVAILABLE status from being overridden by DELETED" in {
-      val availableFur = fur.copy(status = "AVAILABLE")
-      val deletedFur = fur.copy(status = "DELETED")
-      val argument: ArgumentCaptor[FileUploadResponse] = ArgumentCaptor.forClass(classOf[FileUploadResponse])
-      when(repo.save2(argument.capture())).thenReturn(Future.successful(Some(availableFur)))
-      val result = controller.saveFileUploadResponse(fakePostRequest.withBody(toJson(deletedFur)))
-
-      status(result) shouldBe Status.OK
-      argument.getAllValues should contain theSameElementsInOrderAs List(deletedFur)
-    }
-
     "respond with a 400 if FileUploadResponse in request is invalid" in {
       when(repo.save2(any(classOf[FileUploadResponse])))
         .thenReturn(Future.failed(new RuntimeException()))


### PR DESCRIPTION
# DLS-9022 - Change file upload response race condition handling

**Bug fix**

Before we would only store one message per ID and override it depending on the status type coming from the file upload. This appears to be causing problems with the Mongo connector which doesn't seem to handle multiple writes to the same object well.

Now we're going to record all File Upload responses and filter them on read. This will consume a little bit extra mongo disk space, but doesn't cause any problems when writing to the same object. The logic is moved from the controller to the connector, so testing is updated to reflect that.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date