### PR TITLE
DLS-11286 | Relax MX validation

### DIFF
--- a/app/uk/gov/hmrc/cbcr/emailaddress/EmailAddress.scala
+++ b/app/uk/gov/hmrc/cbcr/emailaddress/EmailAddress.scala
@@ -74,14 +74,18 @@ class EmailAddressValidation extends EmailValidation {
     }
   }
 
-  def isValid(email: String): Boolean =
+  def isValid(email: String): Boolean = {
+    val obfuscatedEmail = EmailAddress(email).obfuscated
     email match {
       case validEmail(_, _) if isHostMailServer(EmailAddress(email).domain) => true
+      case validEmail(_, _) =>
+        logger.warn(s"Invalid email Address (host validation failure) : $obfuscatedEmail")
+        true
       case _ =>
-        val obfuscatedEmail = EmailAddress(email).obfuscated
-        logger.error(s"Invalid email Address : $obfuscatedEmail ")
+        logger.error(s"Invalid email Address : $obfuscatedEmail")
         false
     }
+  }
 }
 
 object EmailAddressValidation {

--- a/test/uk/gov/hmrc/cbcr/emailaddress/EmailAddressSpec.scala
+++ b/test/uk/gov/hmrc/cbcr/emailaddress/EmailAddressSpec.scala
@@ -115,10 +115,6 @@ class EmailAddressSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Ma
       email.isValid("mike@gmail.com") shouldBe true
       email.isValid("mike@msn.co.uk") shouldBe true
     }
-    "return false for an invalid domain" in {
-      val email = new EmailAddressValidation
-      email.isValid("mike@fortytwoisnotananswer.org") shouldBe false
-    }
   }
 
   "A email address mailbox" should {


### PR DESCRIPTION
We will be relaxing MX validation on backend for already existing subscriptions. 

With the frontend email validation now being strict, we shouldn't see any such entries going forward. So, frontend acts as the gatekeeper for email validation. Backend, we are just relaxing MX validation but not the regex pattern that includes domain part of email.