### PR TITLE
DLS-12660 | Revert mongo version bump due to library async behaviour change

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ import sbt.*
 object AppDependencies {
   val hmrc = "uk.gov.hmrc"
   val playVersion = "play-30"
-  val mongoVersion = "2.11.0"
+  val mongoVersion = "2.7.0"
   var bootstrapVersion = "10.5.0"
   val mockitoScalaVersion = "3.2.17.0"
 


### PR DESCRIPTION
Issue here is the [mongo update to 2.10.0](https://github.com/hmrc/cgt-property-disposals-frontend/pull/1352/files#diff-34ef524c498e830d38453638b16bce7018ebcdb7e360316a2b7f437b49d9dee1L6) which seems to have brought in a latest minor version bump of underlying mongo-driver. That unfortunately has changed how async operations are handled now. 

We donot want to bring this dependency at a time the service is due for de-commission soon and best to leave this one out as it is causing issues with test controller deletions used in ATs.